### PR TITLE
added insert latex tags button

### DIFF
--- a/MathPix/TeXEditorWindow.xaml
+++ b/MathPix/TeXEditorWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
+        KeyDown="Window_Keydown"
         Title="TeX Editor" Height="550" Width="660">
     <mah:MetroWindow.Resources>
         <ResourceDictionary>
@@ -65,8 +66,14 @@
             <Button Name="BtnInsertTags"
                     Grid.Column="1"
                     VerticalAlignment="Center"
-                    Content="Insert Tags"
-                    Click="BtnInsertTags_Click" />
+                    Click="BtnInsertTags_Click">
+              <Button.Content>
+                <TextBlock>
+                  INSERT <Underline>T</Underline>AGS
+                </TextBlock>
+              </Button.Content>
+            </Button>
+
           
             <Button Name="BtnCancel"
                     Grid.Column="2"

--- a/MathPix/TeXEditorWindow.xaml
+++ b/MathPix/TeXEditorWindow.xaml
@@ -52,6 +52,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
 
             <Button Name="BtnReset"
@@ -61,15 +62,21 @@
                     Content="Reset"
                     Click="BtnReset_Click" />
 
-            <Button Name="BtnCancel"
+            <Button Name="BtnInsertTags"
                     Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Content="Insert Tags"
+                    Click="BtnInsertTags_Click" />
+          
+            <Button Name="BtnCancel"
+                    Grid.Column="2"
                     VerticalAlignment="Center"
                     Margin="6 0 6 0"
                     Content="Cancel"
                     Click="BtnCancel_Click" />
 
             <Button Name="BtnOk"
-                    Grid.Column="2"
+                    Grid.Column="3"
                     VerticalAlignment="Center"
                     Content="Ok"
                     Click="BtnOk_Click" />

--- a/MathPix/TeXEditorWindow.xaml
+++ b/MathPix/TeXEditorWindow.xaml
@@ -5,7 +5,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
-        KeyDown="Window_Keydown"
         Title="TeX Editor" Height="550" Width="660">
     <mah:MetroWindow.Resources>
         <ResourceDictionary>
@@ -67,11 +66,7 @@
                     Grid.Column="1"
                     VerticalAlignment="Center"
                     Click="BtnInsertTags_Click">
-              <Button.Content>
-                <TextBlock>
-                  INSERT <Underline>T</Underline>AGS
-                </TextBlock>
-              </Button.Content>
+              <AccessText>INSERT _TAGS</AccessText>
             </Button>
 
           

--- a/MathPix/TeXEditorWindow.xaml.cs
+++ b/MathPix/TeXEditorWindow.xaml.cs
@@ -138,7 +138,14 @@ namespace SuperMemoAssistant.Plugins.PDF.MathPix
 
     private void BtnInsertTags_Click(object sender, RoutedEventArgs e)
     {
-      TeXInput.SelectedText = "[/$][$]";
+      if (string.IsNullOrEmpty(TeXInput.SelectedText))
+      {
+        TeXInput.SelectedText = "[/$][$]";
+      }
+      else
+      {
+        TeXInput.SelectedText = $"[/$][$]{TeXInput.SelectedText}[/$][$]";
+      }
     }
 
     private void TeXInput_TextChanged(object                                       sender,

--- a/MathPix/TeXEditorWindow.xaml.cs
+++ b/MathPix/TeXEditorWindow.xaml.cs
@@ -127,6 +127,11 @@ namespace SuperMemoAssistant.Plugins.PDF.MathPix
       Close();
     }
 
+    private void BtnInsertTags_Click(object sender, RoutedEventArgs e)
+    {
+      TeXInput.SelectedText = "[/$][$]";
+    }
+
     private void TeXInput_TextChanged(object                                       sender,
                                       System.Windows.Controls.TextChangedEventArgs e)
     {

--- a/MathPix/TeXEditorWindow.xaml.cs
+++ b/MathPix/TeXEditorWindow.xaml.cs
@@ -107,6 +107,15 @@ namespace SuperMemoAssistant.Plugins.PDF.MathPix
                            new object[] { "Preview.Update();" });
       _ignoreTextChange = false;
     }
+    
+    private void Window_KeyDown(object sender, KeyEventArgs e)
+    {
+      if (e.KeyboardDevice.Modifiers == ModifierKeys.Alt
+          && e.SystemKey == Key.T)
+      {
+        BtnInsertTags_Click(sender, e);
+      }
+    }
 
     private void BtnReset_Click(object          sender,
                                 RoutedEventArgs e)

--- a/MathPix/TeXEditorWindow.xaml.cs
+++ b/MathPix/TeXEditorWindow.xaml.cs
@@ -108,15 +108,6 @@ namespace SuperMemoAssistant.Plugins.PDF.MathPix
       _ignoreTextChange = false;
     }
     
-    private void Window_KeyDown(object sender, KeyEventArgs e)
-    {
-      if (e.KeyboardDevice.Modifiers == ModifierKeys.Alt
-          && e.SystemKey == Key.T)
-      {
-        BtnInsertTags_Click(sender, e);
-      }
-    }
-
     private void BtnReset_Click(object          sender,
                                 RoutedEventArgs e)
     {


### PR DESCRIPTION
A very simple addition to the TeXEditor window: A button to insert "[/$][$]" tags at the cursor. Allows creation of multiple Latex images. Requested by Naess.

Before pressing:
![image](https://user-images.githubusercontent.com/58147075/74153081-a67e5280-4c07-11ea-9e52-043790849c6e.png)

After pressing:
![image](https://user-images.githubusercontent.com/58147075/74153102-b433d800-4c07-11ea-91ab-e0693163c914.png)

