### PR TITLE
optionally add html component to image extract

### DIFF
--- a/Models/PDFCfg.cs
+++ b/Models/PDFCfg.cs
@@ -99,6 +99,9 @@ namespace SuperMemoAssistant.Plugins.PDF.Models
                 SelectionType = SelectionType.RadioButtonsInline)]
     public ImageStretchMode ImageStretchType { get; set; } = ImageStretchMode.Proportional;
 
+    [Field(Name = "Add HTML component to extracts containing only images?")]
+    public bool ImageExtractAddHtml { get; set; } = false;
+
     [Field(Name = "Default view mode")]
     [SelectFrom(typeof(ViewModes),
                 SelectionType = SelectionType.ComboBox)]

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -146,12 +146,10 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
       }
       else if (Config.ImageExtractAddHtml && imgExtracts.Count > 0)
       {
-        extractTitle = $"image extract: {imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")} from ";
-        foreach(var pi in pageIndices)
-        {
-          extractTitle += $"p{pi}, ";
-        }
-        extractTitle = extractTitle.TrimEnd(", ");
+        var parentEl = Svc.SM.Registry.Element[PDFElement.ElementId];
+        extractTitle = $"{parentEl.Title} -- Image extract: {imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")} from ";
+        string pageString = "p" + string.Join(", p", pageIndices);
+        extractTitle = $"{extractTitle}{pageString}";
         string text = string.Empty;
         contents.Add(new TextContent(true, text));
       }

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -148,7 +148,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
       {
         var parentEl = Svc.SM.Registry.Element[PDFElement.ElementId];
         extractTitle = $"{parentEl.Title} -- Image extract: {imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")} from ";
-        string pageString = "p" + string.Join(", p", pageIndices);
+        string pageString = "p" + string.Join(", p", pageIndices.Select(p => p+1));
         extractTitle = $"{extractTitle}{pageString}";
         string text = string.Empty;
         contents.Add(new TextContent(true, text));

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -147,9 +147,10 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
       else if (Config.ImageExtractAddHtml && imgExtracts.Count > 0)
       {
         var parentEl = Svc.SM.Registry.Element[PDFElement.ElementId];
-        extractTitle = $"{parentEl.Title} -- Image extract: {imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")} from ";
-        string pageString = "p" + string.Join(", p", pageIndices.Select(p => p+1));
-        extractTitle = $"{extractTitle}{pageString}";
+        string titleString = $"{parentEl.Title} -- Image extract:";
+        string imageString = $"{imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")}";
+        string pageString = "p" + string.Join(", p", pageIndices.Select(p => p + 1));
+        extractTitle = $"{titleString} {imageString} from {pageString}";
         string text = string.Empty;
         contents.Add(new TextContent(true, text));
       }

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -142,6 +142,11 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
 
         contents.Add(new TextContent(true, text));
       }
+      else if (Config.ImageExtractAddHtml)
+      {
+        string text = string.Empty;
+        contents.Add(new TextContent(true, text));
+      }
 
       // Generate extract
       if (contents.Count > 0)

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -64,6 +64,8 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
       var selTextAreas  = SelectedAreas.Where(a => a.Type == PDFAreaSelection.AreaType.Ocr).ToList();
       var pageIndices   = new HashSet<int>();
 
+      string extractTitle = null;
+
       // Image extract
       foreach (var selImage in selImages)
       {
@@ -142,8 +144,14 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
 
         contents.Add(new TextContent(true, text));
       }
-      else if (Config.ImageExtractAddHtml)
+      else if (Config.ImageExtractAddHtml && imgExtracts.Count > 0)
       {
+        extractTitle = $"image extract: {imgExtracts.Count} image{(imgExtracts.Count == 1 ? "" : "s")} from ";
+        foreach(var pi in pageIndices)
+        {
+          extractTitle += $"p{pi}, ";
+        }
+        extractTitle = extractTitle.TrimEnd(", ");
         string text = string.Empty;
         contents.Add(new TextContent(true, text));
       }
@@ -170,7 +178,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
             .WithLayout(Config.Layout)
             .WithPriority(Config.SMExtractPriority)
             .WithReference(r => PDFElement.ConfigureSMReferences(r, bookmarks: bookmarksStr))
-            .WithForcedGeneratedTitle()
+            .WithTitle(extractTitle)
             .DoNotDisplay()
         );
 


### PR DESCRIPTION
Optionally add html component to PDF extracts containing only images as requested by @nikedinikedi .    The option can be set in the PDF config settings. 

The only thing that seems off to me is that the titles of the extracts looks like the picture below. Let me know if this is an issue, I am more than willing to fix this, because admittedly this is a very simple solution.

![image](https://user-images.githubusercontent.com/58147075/74289330-a7f26c80-4d26-11ea-871a-d33a7b9e100b.png)

  