### PR TITLE
extract PDF bookmark with priority

### DIFF
--- a/PDF/PDFElement.cs
+++ b/PDF/PDFElement.cs
@@ -291,13 +291,20 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF
       int       pageMargin      = PDFConst.DefaultPageMargin,
       float     zoom            = PDFConst.DefaultZoom,
       bool      shouldDisplay   = true,
-      string    subtitle        = null)
+      string    subtitle        = null,
+      double    priority        = -1)
     {
       PDFElement pdfEl;
       string     title;
       string     author;
       string     creationDate;
       string     filePath;
+
+
+      if (priority < 0 || priority > 100)
+      {
+        priority = PDFState.Instance.Config.PDFExtractPriority;
+      }
 
       try
       {
@@ -348,7 +355,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF
                            elementHtml)
           .WithParent(parentElement)
           .WithTitle(subtitle ?? title)
-          .WithPriority(PDFState.Instance.Config.PDFExtractPriority)
+          .WithPriority(priority)
           .WithReference(
             r => r.WithTitle(title)
                   .WithAuthor(author)

--- a/PDF/PDFWindow.xaml.cs
+++ b/PDF/PDFWindow.xaml.cs
@@ -41,6 +41,8 @@ using Microsoft.Win32;
 using Patagames.Pdf.Net;
 using SuperMemoAssistant.Extensions;
 using SuperMemoAssistant.Plugins.PDF.Models;
+using System.Threading.Tasks;
+using Forge.Forms;
 using SuperMemoAssistant.Services.IO.HotKeys;
 using SuperMemoAssistant.Sys.IO.Devices;
 using SuperMemoAssistant.Sys.Threading;
@@ -342,6 +344,28 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF
       IPDFViewer.ExtractBookmark(bookmark);
     }
 
+    private async void TvBookmark_MenuItem_PDFExtractWithPriority(object sender,
+                                            RoutedEventArgs e)
+    {
+
+      var result = await Forge.Forms.Show.Window()
+        .For(new Prompt<double> { Title = "Bookmark Priority?", Value = -1 });
+
+      if (!result.Model.Confirmed)
+      {
+        return;
+      }
+
+      PdfBookmark bookmark = (PdfBookmark)tvBookmarks.SelectedItem;
+      if (bookmark == null)
+      {
+        return;
+      }
+
+      IPDFViewer.ExtractBookmark(bookmark, result.Model.Value);
+    }
+
+
     private void TvBookmarks_PreviewKeyDown(object       sender,
                                             KeyEventArgs e)
     {
@@ -362,6 +386,14 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF
         TvBookmark_MenuItem_PDFExtract(sender,
                                        null);
 
+        e.Handled = true;
+      }
+
+      else if (kbMod == (KeyModifiers.Ctrl | KeyModifiers.Shift)
+        && e.Key == Key.X)
+      {
+        TvBookmark_MenuItem_PDFExtractWithPriority(sender,
+                                                   null);
         e.Handled = true;
       }
     }

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -225,7 +225,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
 
     // PDF Extracts
 
-    protected bool CreatePDFExtract()
+    protected bool CreatePDFExtract(double priority = -1)
     {
       bool ret = false;
 
@@ -263,7 +263,8 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
     }
 
     protected bool CreatePDFExtract(SelectInfo selInfo,
-                                    string     title = null)
+                                    string     title = null,
+                                    double priority = -1)
     {
       Save(false);
 
@@ -282,7 +283,8 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
                                    PDFElement.PageMargin,
                                    PDFElement.Zoom,
                                    false,
-                                   title) == PDFElement.CreationResult.Ok;
+                                   title,
+                                   priority) == PDFElement.CreationResult.Ok;
 
       if (ret)
       {

--- a/PDF/Viewer/IPDFViewer.cs
+++ b/PDF/Viewer/IPDFViewer.cs
@@ -253,7 +253,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
         OnDocumentLoaded(null);
     }
 
-    public void ExtractBookmark(PdfBookmark bookmark)
+    public void ExtractBookmark(PdfBookmark bookmark, double priority = -1)
     {
       var selInfo = bookmark.GetSelection(Document);
 
@@ -261,7 +261,8 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
         return;
 
       CreatePDFExtract(selInfo.Value,
-                       bookmark.Title);
+                       bookmark.Title,
+                       priority);
     }
 
     public void ProcessBookmark(PdfBookmark bookmark)


### PR DESCRIPTION
Allows you to extract a bookmark from a PDF and specify the priority in a popup window.

1. Select bookmark

![image](https://user-images.githubusercontent.com/58147075/74613486-c5e51600-5106-11ea-9148-94b6b3445229.png)

2. Press Ctrl-Shift-X and type the priority

![image](https://user-images.githubusercontent.com/58147075/74613508-f331c400-5106-11ea-97a7-561b762157a2.png)

3. Bookmark gets extracted

![image](https://user-images.githubusercontent.com/58147075/74613527-21170880-5107-11ea-9705-240e1311d073.png)


