### PR TITLE
Pdf extract priority

### DIFF
--- a/PDF/Viewer/IPDFViewer.Inputs.cs
+++ b/PDF/Viewer/IPDFViewer.Inputs.cs
@@ -96,6 +96,11 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
           e.Handled = true;
           break;
 
+        case PDFHotKeys.ExtractSMWithPriority:
+          CreateSMExtractWithPriority();
+          e.Handled = true;
+          break;
+
         case PDFHotKeys.MarkIgnore:
           CreateIgnoreHighlight();
           e.Handled = true;

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows;
+using Forge.Forms;
 using Patagames.Pdf;
 using Patagames.Pdf.Net;
 using Patagames.Pdf.Net.Controls.Wpf;

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -215,16 +215,18 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
     protected async void CreateSMExtractWithPriority()
     {
 
+      // TODO: Create a better generic Prompt with: a) a description parameter, b) constraints parameters
       var result = await Show.Window()
-                         .For(new Prompt<double> { Title = "Extract Priority?", Value = -1 });
+                             .For(new Prompt<double> { Title = "Extract Priority?", Value = Config.SMExtractPriority });
       if (!result.Model.Confirmed)
       {
-          return;
+        return;
       }
 
       if (result.Model.Value < 0 || result.Model.Value > 100)
       {
-          return;
+        await Show.Window().For(new Alert("Priority must be a value between 0 and 100."));
+        return;
       }
 
       CreateSMExtract(result.Model.Value);

--- a/PDF/Viewer/IPDFViewer.SuperMemo.cs
+++ b/PDF/Viewer/IPDFViewer.SuperMemo.cs
@@ -51,7 +51,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
   {
     #region Methods
 
-    protected bool CreateSMExtract()
+    protected bool CreateSMExtract(double priority = -1)
     {
       bool ret = false;
 
@@ -148,6 +148,11 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
       {
         Save(false);
 
+        if (priority < 0 || priority > 100)
+        {
+          priority = Config.SMExtractPriority;
+        }
+
         var bookmarks = pageIndices.Select(FindBookmark)
                                    .Where(b => b != null)
                                    .Distinct()
@@ -163,7 +168,7 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
             .WithParent(parentEl)
             .WithConcept(parentEl.Concept)
             .WithLayout(Config.Layout)
-            .WithPriority(Config.SMExtractPriority)
+            .WithPriority(priority)
             .WithReference(r => PDFElement.ConfigureSMReferences(r, bookmarks: bookmarksStr))
             .WithForcedGeneratedTitle()
             .DoNotDisplay()
@@ -205,6 +210,25 @@ namespace SuperMemoAssistant.Plugins.PDF.PDF.Viewer
 
       return ret;
     }
+
+    protected async void CreateSMExtractWithPriority()
+    {
+
+      var result = await Show.Window()
+                         .For(new Prompt<double> { Title = "Extract Priority?", Value = -1 });
+      if (!result.Model.Confirmed)
+      {
+          return;
+      }
+
+      if (result.Model.Value < 0 || result.Model.Value > 100)
+      {
+          return;
+      }
+
+      CreateSMExtract(result.Model.Value);
+    }
+
 
     protected ContentBase CreateImageContent(Image  image, string title)
     {

--- a/PDFHotKeys.cs
+++ b/PDFHotKeys.cs
@@ -63,15 +63,16 @@ namespace SuperMemoAssistant.Plugins.PDF
     public const string UIToggleBookmarks  = "UIToggleBookmarks";
     public const string UIFocusViewer      = "UIFocusViewer";
     public const string UIFocusBookmarks   = "UIFocusBookmarks";
+    public const string ExtractSMWithPriority = "ExtractSMWithPriority";
 
-    #endregion
+        #endregion
 
 
 
 
-    #region Methods
+        #region Methods
 
-    public static void RegisterHotKeys()
+        public static void RegisterHotKeys()
     {
       Svc.HotKeyManager
 
@@ -99,6 +100,12 @@ namespace SuperMemoAssistant.Plugins.PDF
                         "Mark text as ignored",
                         new HotKey(Key.I, KeyModifiers.CtrlShift)
          )
+         .RegisterLocal(ExtractSMWithPriority,
+                        "Create SM extract with priority",
+                        // Alt+Shift+X wasn't working
+                        new HotKey(Key.X, KeyModifiers.CtrlAltShift)
+         )
+
 
          //
          // PDF features


### PR DESCRIPTION
Allows you to set the priority of a PDF text / image extract.

1. Highlight text / images to extract:

![image](https://user-images.githubusercontent.com/58147075/74614785-ca173080-5112-11ea-98d9-30639238980a.png)

2. Press Ctrl-Shift-Alt-X (Alt-Shift-X wouldn't work for me) and set the priority of the extract.

![image](https://user-images.githubusercontent.com/58147075/74614788-dd2a0080-5112-11ea-8fc8-29feaece0bac.png)

